### PR TITLE
adding languages to the latex babel export. Adding settings to overri…

### DIFF
--- a/OrgExtended.sublime-settings
+++ b/OrgExtended.sublime-settings
@@ -275,4 +275,12 @@
 
     // Should we execute our source blocks on export?
     "htmlExecuteSourceOnExport": true,
+
+    // LaTeX path for Org Export File As Pdf
+    // "latex2Pdf": "C:\\texlive\\2021\\bin\\win32\\pdflatex.exe",
+    // LateX SRC_BLOC - LaTex Listing package language matching
+    // "latexListingPackageLang": {
+    //     "python":  "Python",
+    //     "lua":   "[5.2]Lua",
+    // },
 }

--- a/orglatex.py
+++ b/orglatex.py
@@ -39,7 +39,7 @@ langMap = {
     "perl": "Perl",
     "bash": "bash",
     "sh": "sh",
-    "lua": "Lua",
+    "lua": "[5.0]Lua",
     "java": "Java",
     "php": "PHP",
     "xml": "XML",
@@ -56,6 +56,9 @@ langMap = {
     "erlang": "erlang",
     "gnuplot": "Gnuplot",
 }
+
+# overriding it by users settings
+langMap.update(sets.Get("latexListingPackageLang",langMap))
 
 def haveLang(lang):
     return lang in langMap
@@ -125,7 +128,7 @@ class LatexSourceBlockState(exp.SourceBlockState):
             return
         attribs = ""
         if(haveLang(language)):
-            self.e.doc.append(r"  \begin{{lstlisting}}[language={lang}]".format(lang=mapLanguage(language)))
+            self.e.doc.append(r"  \begin{{lstlisting}}[language={{{lang}}}]".format(lang=mapLanguage(language)))
         else:
             self.e.doc.append(r"  \begin{lstlisting}")
 


### PR DESCRIPTION
…de default listing's package choice.

The setting "latexListingPackageLang" has been added to the settings file.
Languages were all tested with following org file:

#+TITLE: latex block export

* Heading 1
Testing the babel export to latex.
** Let's hello word 
*** "cpp"
    #+BEGIN_SRC cpp
    #include <iostream>
 
    int main()
    {
        std::cout << "Hello, new world!\n";
    }
    #+END_SRC 
*** "python"
   #+BEGIN_SRC python
     import re
     print("Hello world")
   #+END_SRC
*** "C"
    #+BEGIN_SRC C
    #include <stdio.h>

    main()
    {
        printf("hello, world\n");
    }
    #+END_SRC 
*** "perl"
    #+BEGIN_SRC perl
    print "Hello, world!\n";
    say "Hello, world!";
    #+END_SRC 
*** "bash"
    #+BEGIN_SRC bash
    echo 'Hello, world!'
    #+END_SRC 
*** "sh"
    #+BEGIN_SRC sh
    echo 'Hello, world!'
    #+END_SRC 
*** "lua"
    #+BEGIN_SRC lua
    print("Hello, world!")
    #+END_SRC 
*** "java"
    #+BEGIN_SRC java
    public class HelloWorld {
    public static void main(String[] args) {
        System.out.println("Hello, world!"); 
        }
    } 
    #+END_SRC 
*** "php"
    #+BEGIN_SRC php
    <?php
     echo "Hello, world!";
    ?>
    #+END_SRC 
*** "xml"
    #+BEGIN_SRC xml
    <ul compact="compact">
        <li>Item 1</li>
        <li>Item<br/>2</li>
    </ul>
    #+END_SRC 
*** "lisp"
    #+BEGIN_SRC lisp
    (princ "Hello, world!")
    #+END_SRC 
*** "sql"
    #+BEGIN_SRC sql
    print 'Hello, world!'
    #+END_SRC 
*** "r"
    #+BEGIN_SRC r
    cat("Hello, world!\n")
    #+END_SRC 
*** "html"
    #+BEGIN_SRC html
    <!DOCTYPE html>
    <html>
        <head>
            <meta charset="utf-8">
            <title>Hello, world!</title>
        </head>
        <body>
            <p>Hello, world!</p>
        </body>
    </html>
    #+END_SRC 
*** "go"
    #+BEGIN_SRC go
    package main

    import "fmt"

    func main() {
       fmt.Println("Hello, world!")
    }
    #+END_SRC 
*** "make"
    #+BEGIN_SRC make
    all: cible1 cible2
        echo ''all : ok''

    cible1:
            echo ''cible1 : ok''

    cible2:
            echo ''cible2 : ok''
    #+END_SRC 
*** "pascal"
    #+BEGIN_SRC pascal
    PROGRAM salutation; // Facultatif
    BEGIN
        writeln('Hello, world!');
        readln; // Nécessaire pour marquer une pause à la fin de l'affichage, à défaut le programme termine.
    END.
    #+END_SRC 
*** "ruby"
    #+BEGIN_SRC ruby
    puts "Hello, world!"
    #+END_SRC 
*** "xsl"
    #+BEGIN_SRC xsl
    <?xml version="1.0" encoding="UTF-8"?>
    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
          version="2.0">
    <xsl:template match="/">Hello, world!</xsl:template>
    </xsl:stylesheet>
    #+END_SRC 
*** "scala"
    #+BEGIN_SRC scala
    object HelloWorld extends App {
        println("Hello, world!");
    }
    #+END_SRC 
*** "erlang"
    #+BEGIN_SRC erlang
    -module(hello).
    -export([hello_world/0]).

    hello_world() -> io:fwrite("Hello, world!\n").
    #+END_SRC 
*** "gnuplot"
    #+BEGIN_SRC gnuplot
    print "Hello, world!"
    #+END_SRC 
[`](url)
`