### PR TITLE
Fix durationfilter

### DIFF
--- a/orgagenda.py
+++ b/orgagenda.py
@@ -630,20 +630,20 @@ class AgendaBaseView:
         if(self._oneofStateTags and len(self._oneofStateTags) > 0 and not any(re.search(elem,t) for elem in self._oneofStateTags)):
             return False
         return True
-    
+
     def MatchDuration(self, node):
         t = node.closed
-        if(t and self._afterDuration and any(t.after(elem) for elem in self._afterDuration)):
+        if(t and self._afterDuration and any(not t.after_duration(elem) for elem in self._afterDuration)):
             return False
-        if(self._beforeDuration):
+        if self._beforeDuration:
             s = node.scheduled
             d = node.deadline
-            ts = node.timestamps
-            if(s and any(s and s.before(elem) for elem in self._beforeDuration)):
+            ts = node.get_timestamps()
+            if(s and any(s and s.before_duration(elem) for elem in self._beforeDuration)):
                 return True
-            if(d and any(d and d.before(elem) for elem in self._beforeDuration)):
+            if(d and any(d and d.before_duration(elem) for elem in self._beforeDuration)):
                 return True
-            if(ts and len(ts) > 0 and any(ts[0] and ts[0].before(elem) for elem in self._beforeDuration)):
+            if(ts and len(ts) > 0 and any(ts[0] and ts[0].before_duration(elem) for elem in self._beforeDuration)):
                 return True
             return False
         return True

--- a/orgparse/date.py
+++ b/orgparse/date.py
@@ -271,11 +271,12 @@ class OrgDate(object):
             return OrgDate(self._start - td,self._end - td if self._end else None,self._active,self.repeat_rule,self.warn_rule)
         return self 
 
-    def before(self, duration):
+    def before_duration(self, duration):
         return self._start <= (datetime.datetime.now() + duration.timedelta())
     
-    def after(self, duration):
-        return self._end >= (datetime.datetime.now() - duration.timedelta())
+    def after_duration(self, duration):
+        end = self._end if self._end is not None else self._start
+        return end >= (datetime.datetime.now() - duration.timedelta())
 
     @staticmethod
     def format_date(now, active):


### PR DESCRIPTION
I found something goes wrong with my machine so I tried to fix them. I never use the clock feature so maybe it doesn't appear on your side.

1. `after` and `before` are duplicated func names
2. No property named `timestamps` in the node
3. `_end` is not always existing
4. `after duration` matching condition is flipped maybe?
