### PR TITLE
Small fixes in Agenda

### DIFF
--- a/asettings.py
+++ b/asettings.py
@@ -10,7 +10,7 @@ import OrgExtended.orgutil.template as temp
 log = logging.getLogger(__name__)
 
 defaultTodoStates = ["TODO", "NEXT", "BLOCKED","WAITING","|", "CANCELLED", "DONE","MEETING","PHONE","NOTE"]
-daysOfWeek = ["sun","mon","tue","wed","th","fri","sat"]
+weekdayNames = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
 
 class ASettings:
@@ -119,15 +119,9 @@ def GetInt(name, defaultValue):
 	except:
 		return defaultValue
 
-# Will return a date or an index as an integer where 0 means Sunday
-# and so on in the week.
-def GetDateAsIndex(name, defaultValue):
-	global daysOfWeek
-	val = Get(name, defaultValue)
-	if(RepresentsInt(val)):
-		return int(val) % 7
-	val = val.lower()
-	for i in range(0,len(daysOfWeek)):
-		if daysOfWeek[i] in val:
-			return i
-	return 0
+def GetWeekdayIndexByName(name):
+    try:
+        weekdayIndex = weekdayNames.index(name)
+    except:
+        weekdayIndex = 6
+    return weekdayIndex

--- a/orgagenda.py
+++ b/orgagenda.py
@@ -184,11 +184,20 @@ def IsTodaysDate(check, today):
 
 def IsInMonthCheck(t, now):
     if(IsRawDate(t)):
-        if (t.month >= (now.month-1) and t.month <= (now.month+1)):
-            return t
+        dateT = t
     else:
-        if (t.start.month >= (now.month-1) and t.start.month <= (now.month+1)):
-            return t.start
+        dateT = datetime.date(t.start.year, t.start.month, t.start.day)
+
+    if (dateT.year == now.year):
+        if (dateT.month >= (now.month-1) and dateT.month <= (now.month+1)):
+            return True
+        else:
+            return False
+    if (dateT.year == now.year + 1) and (dateT.month == 0 and now.month == 11):
+        return True
+    if (dateT.year == now.year - 1) and (dateT.month == 11 and now.month == 0):
+        return True
+    return False
 
 def IsInMonth(n, now):
     if(not n):

--- a/orgagenda.py
+++ b/orgagenda.py
@@ -784,8 +784,8 @@ def IsAfterNow(ts, now):
 class CalendarView(AgendaBaseView):
     def __init__(self, name, setup=True,**kwargs):
         super(CalendarView, self).__init__(name, setup, **kwargs)
-        dayOffset = sets.GetDateAsIndex("firstDayOfWeek","Sunday")
-        self.dv = dpick.DateView("orgagenda.now",firstDayOffset = dayOffset)
+        firstDayIndex = sets.GetWeekdayIndexByName(sets.Get("firstDayOfWeek","Sunday"))
+        self.dv = dpick.DateView("orgagenda.now",firstDayIndex = firstDayIndex)
 
     def UpdateNow(self, now=None):
         if(now == None):
@@ -981,22 +981,15 @@ class WeekView(AgendaBaseView):
     def RenderView(self, edit):
         self.InsertAgendaHeading(edit)
         self.InsertTimeHeading(edit,self.now.hour)
-        toHighlight = []
         #print(str(self.now))
         wday   = self.now.weekday()
-        # Adjust for Sunday being day 6 and we start with dunday
-        if(wday >= 6):
-            wday = -1
-        wstart = self.now + datetime.timedelta(days=-(wday+1))
-        dayNames  = ["Sun","Mon", "Tue", "Wed", "Thr", "Fri", "Sat"]
-        dayOffset = sets.GetDateAsIndex("firstDayOfWeek","Sunday")
+        firstDayIndex = sets.GetWeekdayIndexByName(sets.Get("firstDayOfWeek", "Sunday"))
+        wstart = self.now + datetime.timedelta(days=firstDayIndex-wday)
+        dayNames  = sets.Get("weekViewDayNames",["Mon", "Tue", "Wed", "Thr", "Fri", "Sat", "Sun"])
         numDays   = sets.Get("agendaWeekViewNumDays",7)
         for i in range(0,numDays):
-            index = dayOffset + i
-            if(index == 0):
-                self.InsertDay(dayNames[index % len(dayNames)], wstart, edit)
-            else:
-                self.InsertDay(dayNames[index % len(dayNames)], wstart + datetime.timedelta(days=index) , edit)
+            index = (firstDayIndex + i) % len(dayNames)
+            self.InsertDay(dayNames[index], wstart + datetime.timedelta(days=i), edit)
 
     def FilterEntry(self, n, filename):
         rc = (not self.onlyTasks or (IsTodo(node) or IsDone(n))) and not IsProject(n) and HasTimestamp(n)

--- a/orgagenda.py
+++ b/orgagenda.py
@@ -1358,7 +1358,7 @@ class CompositeViewListener(sublime_plugin.ViewEventListener):
         self.clear_phantoms()
     
     def on_hover(self, point, hover_zone):
-        if(not hasattr(self,agenda) or self.agenda == None):
+        if(not hasattr(self,'agenda') or self.agenda == None):
             return
         if(hover_zone == sublime.HOVER_TEXT):
             row,col = self.view.rowcol(point)

--- a/orgdatepicker.py
+++ b/orgdatepicker.py
@@ -48,7 +48,7 @@ class DateView:
 
 	def DateToRegion(self, date):
 		# Convert 
-		monthIndex = (date.month - self.midmonth + 1)
+		monthIndex = (date.month - (self.midmonth) + 1) % 12
 		if(monthIndex < 0 or monthIndex >= len(self.monthdata)):
 			return
 		monthData = self.monthdata[monthIndex]
@@ -212,7 +212,8 @@ class DateView:
 	def ResetRenderState(self):
 		self.output.set_read_only(True)
 		self.output.set_scratch(True)
-		self.output.set_name("DatePicker")
+		if not self.output.name():
+			self.output.set_name("DatePicker")
 
 
 class DatePicker:

--- a/orgdatepicker.py
+++ b/orgdatepicker.py
@@ -22,7 +22,7 @@ def CreateUniqueViewNamed(name, mapped=None):
 	return view
 
 class DateView:
-	def __init__(self, dayhighlight=None,firstDayOffset=0):
+	def __init__(self, dayhighlight=None,firstDayIndex=0):
 		self.months = []
 		self.columnsPerMonth = 30                     # 7 * 3 = 21 + 9
 		self.columnsInDay    = 2  
@@ -35,7 +35,7 @@ class DateView:
 		self.startrow        = 0
 		self.endrow          = 7
 		self.dayhighlight    = dayhighlight
-		self.firstdayoffset  = firstDayOffset
+		self.firstdayindex   = firstDayIndex
 
 
 	def SetView(self, view):
@@ -166,9 +166,8 @@ class DateView:
 		return (month, year)
 
 	def Render(self,now):
-		days = [calendar.SUNDAY, calendar.MONDAY, calendar.TUESDAY, calendar.WEDNESDAY, calendar.THURSDAY, calendar.FRIDAY, calendar.SATURDAY]
-		offset = self.firstdayoffset % 7
-		firstDay = days[offset]
+		days = [calendar.MONDAY, calendar.TUESDAY, calendar.WEDNESDAY, calendar.THURSDAY, calendar.FRIDAY, calendar.SATURDAY, calendar.SUNDAY]
+		firstDay = days[self.firstdayindex]
 		c = calendar.TextCalendar(firstDay)
 		str = c.formatmonth(now.year, now.month)
 		calendar.setfirstweekday(firstDay)
@@ -217,8 +216,8 @@ class DateView:
 
 
 class DatePicker:
-	def __init__(self,firstDayOffset=0):
-		self.dateView = DateView(None, firstDayOffset)
+	def __init__(self,firstDayIndex=0):
+		self.dateView = DateView(None, firstDayIndex)
 		self.months = []
 
 	def on_done(self, text):
@@ -351,6 +350,6 @@ class OrgDatePickerNextMonthCommand(sublime_plugin.TextCommand):
 
 def Pick(onDone):
 	global datePicker
-	dayOffset = sets.GetDateAsIndex("firstDayOfWeek","Sunday")
-	datePicker = DatePicker(dayOffset)
+	firstDayIndex = sets.GetWeekdayIndexByName(sets.Get("firstDayOfWeek","Sunday"))
+	datePicker = DatePicker(firstDayIndex)
 	datePicker.Show(datetime.datetime.now(), onDone)


### PR DESCRIPTION
While working on Agenda part of plugin (I plan to bring PR with enhancements soon), I fixed some bugs. Please, take a look:

1. `d37fb7` fixes a typo (`hasattr()` wants a string as second argument)
2. `798b00` fixes stepping over year's border:
    - corrects month's index
    - makes `ResetRenderState` not to think everything is `DatePicker`
3. `9b8803` fixes WeekView:
    If someone (like me) prefers Monday as first day of the week and opens Agenda on Sunday, WeekView will be showing next week instead of current.
    I rewrote code a bit to unify for different starting days
4. `8cc6fe` fixes timestamps showing (those red squares) in wrong years. Previously only month was checked
