### PR TITLE
Add file_exclude_patterns to default settings

### DIFF
--- a/OrgExtended.sublime-settings
+++ b/OrgExtended.sublime-settings
@@ -20,6 +20,14 @@
     // Tags will get inserted at this column
     "tagColumn" : 80,
 
+    // Files which should be loaded outside Sublime when a file link is followed
+    "file_exclude_patterns": [
+        "*.pdf",
+        "*.doc",
+        "*.docx",
+        "*.docm",
+    ],
+
 
     // ============================================================
     // ORG DIRS:

--- a/messages/1.2.4.org
+++ b/messages/1.2.4.org
@@ -7,7 +7,7 @@
    If there is a file type you want launched outside of sublime use:
 
    #+BEGIN_EXAMPLE
-     "file_exclude_pattern": ["*.pdf"],
+     "file_exclude_patterns": ["*.pdf"],
    #+END_EXAMPLE
 
 ** Column View


### PR DESCRIPTION
Fixes https://github.com/ihdavids/orgextended/issues/55 and https://github.com/ihdavids/orgextended/issues/79#issuecomment-1865819945  -- OrgExtended will no longer open binary file formats like PDF and Microsoft Word within Sublime, and users can see how to add other file types they want opened externally to the list.