### PR TITLE
Add 'six' to the dependencies

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -6,7 +6,8 @@
 			"dateutil",
 			"requests",
 			"regex",
-			"websocket"
+			"websocket",
+			"six"
 		]
 	}
 }


### PR DESCRIPTION
Proposed change to fix the following error on plugin load:
```
ModuleNotFoundError: No module named 'six'
```

I also had to install the `six` package manually to get it going again.